### PR TITLE
Ensure VPC flow logging is enabled

### DIFF
--- a/02-GKE/vpc.tf
+++ b/02-GKE/vpc.tf
@@ -10,4 +10,6 @@ resource "google_compute_subnetwork" "subnet" {
   region        = var.region
   network       = google_compute_network.vpc.name
   ip_cidr_range = "10.10.0.0/24"
+  enable_flow_logs = true
 }
+


### PR DESCRIPTION
This pull request improves our infrastructure by fixing a security issue found by [Shisho Cloud](https://shisho.dev).

VPC flow logging which allows us to audit traffic in your network is disabled for your VPC subnet. It is better to enable the feature.

