### PR TITLE
Ensure a service account is configured

### DIFF
--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -168,6 +168,9 @@ resource "google_container_cluster" "cluster" {
   }
 
   resource_labels = var.resource_labels
+  node_config {
+    service_account = "<write value as you like (e.g. service-account@example.com)>"
+  }
 }
 
 # ---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This pull request improves our infrastructure by fixing a security issue found by [Shisho Cloud](https://shisho.dev).

## Description from Shisho Cloud

The service account for your GKE cluster is not configured. It is better to create and select a service account that has limited privileges.

